### PR TITLE
Style/frontend/record

### DIFF
--- a/frontend/src/components/pages/Record.tsx
+++ b/frontend/src/components/pages/Record.tsx
@@ -1,23 +1,31 @@
 import { Stack } from "@mui/system";
-import { Box, Typography } from "@mui/material";
+import { Box, Container, Typography } from "@mui/material";
 import DescriptionIcon from "@mui/icons-material/Description";
 import FolderOutlinedIcon from "@mui/icons-material/FolderOutlined";
 import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
 import EditNoteIcon from "@mui/icons-material/EditNote";
 import { IconButton } from "../utils/IconButton";
+import TopSection from "../utils/TopSection";
+import { MainBottomNavigation } from "../utils/MainBottomNavigation";
 
 export const Record = () => {
   return (
-    <Stack sx={{ margin: "0 auto", width: "90%", p: 3 }}>
-      <Typography align="left" sx={{ marginBottom: "30px", fontSize: "2rem", color: "primary.main" }}>
-        記録
-      </Typography>
-      <Box sx={{ display: "flex", placeContent: "center", flexWrap: "wrap", justifyContent: "space-between" }}>
-        <IconButton icon={<DescriptionIcon sx={{ fontSize: "60px" }} />} text="会話の記録" url="conversationrecords" />
-        <IconButton icon={<FolderOutlinedIcon sx={{ fontSize: "60px" }} />} text="履歴" url="history" />
-        <IconButton icon={<EmojiEventsIcon sx={{ fontSize: "60px" }} />} text="データ" url="stats" />
-        <IconButton icon={<EditNoteIcon sx={{ fontSize: "60px" }} />} text="持ち込みメモ" url="memo" />
-      </Box>
-    </Stack>
+    <Container sx={{ display: "flex", flexDirection: "column", justifyContent: "space-between", height: "100vh" }}>
+      <Container sx={{ p: 3 }}>
+        <TopSection />
+        <Stack sx={{ margin: "30px auto 0", width: "90%" }}>
+          <Typography align="left" sx={{ marginBottom: "30px", fontSize: "2rem", color: "primary.main" }}>
+            記録
+          </Typography>
+          <Box sx={{ display: "flex", placeContent: "center", flexWrap: "wrap", justifyContent: "space-between" }}>
+            <IconButton icon={<DescriptionIcon sx={{ fontSize: "60px" }} />} text="会話の記録" url="conversationrecords" />
+            <IconButton icon={<FolderOutlinedIcon sx={{ fontSize: "60px" }} />} text="履歴" url="history" />
+            <IconButton icon={<EmojiEventsIcon sx={{ fontSize: "60px" }} />} text="データ" url="stats" />
+            <IconButton icon={<EditNoteIcon sx={{ fontSize: "60px" }} />} text="持ち込みメモ" url="memo" />
+          </Box>
+        </Stack>
+      </Container>
+      <MainBottomNavigation value="record" />
+    </Container>
   );
 };

--- a/frontend/src/components/pages/Record.tsx
+++ b/frontend/src/components/pages/Record.tsx
@@ -8,8 +8,8 @@ import { IconButton } from "../utils/IconButton";
 
 export const Record = () => {
   return (
-    <Stack sx={{ margin: "0 auto", width: "90%" }}>
-      <Typography align="left" sx={{ marginBottom: "30px", fontSize: "2rem", color: "#da0063" }}>
+    <Stack sx={{ margin: "0 auto", width: "90%", p: 3 }}>
+      <Typography align="left" sx={{ marginBottom: "30px", fontSize: "2rem", color: "primary.main" }}>
         記録
       </Typography>
       <Box sx={{ display: "flex", placeContent: "center", flexWrap: "wrap", justifyContent: "space-between" }}>

--- a/frontend/src/components/pages/Record.tsx
+++ b/frontend/src/components/pages/Record.tsx
@@ -7,14 +7,16 @@ import EditNoteIcon from "@mui/icons-material/EditNote";
 import { IconButton } from "../utils/IconButton";
 import TopSection from "../utils/TopSection";
 import { MainBottomNavigation } from "../utils/MainBottomNavigation";
+import { LibraryBooks } from "@mui/icons-material";
 
 export const Record = () => {
   return (
     <Container sx={{ display: "flex", flexDirection: "column", justifyContent: "space-between", height: "100vh" }}>
-      <Container sx={{ p: 3 }}>
+      <Container sx={{ pt: 3 }}>
         <TopSection />
         <Stack sx={{ margin: "30px auto 0", width: "90%" }}>
-          <Typography align="left" sx={{ marginBottom: "30px", fontSize: "2rem", color: "primary.main" }}>
+          <Typography variant="h4" sx={{ mb: 4, fontWeight: "bold", textAlign: "left" }}>
+            <LibraryBooks sx={{ fontSize: 40, mr: 2, verticalAlign: "bottom" }} />
             記録
           </Typography>
           <Box sx={{ display: "flex", placeContent: "center", flexWrap: "wrap", justifyContent: "space-between" }}>

--- a/frontend/src/components/utils/IconButton.tsx
+++ b/frontend/src/components/utils/IconButton.tsx
@@ -21,8 +21,8 @@ export const IconButton = ({ icon, text, url }: IconButtonProps) => {
         flexDirection: "column",
         gap: "10px",
         borderRadius: "10px",
-        backgroundColor: "#f2d66f",
-        color: "#da0063",
+        backgroundColor: "secondary.main",
+        color: "primary.main",
         fontSize: "1rem",
       }}
       onClick={() => navigate("/" + url)}


### PR DESCRIPTION
## チケットへのリンク

- なし

## やったこと

- 記録画面のスタイルを調整した
- IconButtonの背景色の変更
- TopSectionとBottomNavigationの追加

## やらないこと

- なし

## できるようになること（ユーザ目線）

- この画面からホーム，セッション，設定，通知画面に直接遷移することができるようになった．

## できなくなること（ユーザ目線）

- なし

## 動作確認

- npm run dev で動作確認済み

## その他

- 特になし
