### PR TITLE
Style/frontend/memo

### DIFF
--- a/frontend/src/components/pages/Memo.tsx
+++ b/frontend/src/components/pages/Memo.tsx
@@ -1,4 +1,4 @@
-import { Container, Stack, Typography } from "@mui/material";
+import { Button, Container, Stack, Typography } from "@mui/material";
 import EditNoteIcon from "@mui/icons-material/EditNote";
 import { BottomNavigationTemplate } from "../templates/BottomNavigationTemplate";
 import TopSection from "../utils/TopSection";
@@ -22,6 +22,20 @@ const MemoContainer = () => {
             持ち込みメモ
           </Typography>
           <MemoInputField />
+          <Button
+            variant="contained"
+            fullWidth
+            sx={{
+              backgroundColor: "primary.main",
+              color: "secondary.main",
+              marginY: 2,
+              "&:hover": {
+                backgroundColor: "#FF3399",
+              },
+            }}
+          >
+            保存
+          </Button>
         </Stack>
       </Container>
     </Container>

--- a/frontend/src/components/pages/Memo.tsx
+++ b/frontend/src/components/pages/Memo.tsx
@@ -1,34 +1,30 @@
-import React, { useState } from "react";
-import { TextField } from "@mui/material";
-import { Box } from "@mui/system";
+import { Container, Stack, Typography } from "@mui/material";
+import EditNoteIcon from "@mui/icons-material/EditNote";
 import { BottomNavigationTemplate } from "../templates/BottomNavigationTemplate";
+import TopSection from "../utils/TopSection";
+import { MemoInputField } from "../utils/MemoInputField";
 
 const MemoContainer = () => {
-  const [text, setText] = useState("");
-  const maxLength = 500;
-
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setText(event.target.value.slice(0, maxLength));
-  };
-
   return (
-    <Box sx={{ margin: 2 }}>
-      <TextField
-        label="持ち込みメモ"
-        multiline
-        fullWidth
-        variant="outlined"
-        value={text}
-        onChange={handleChange}
-        helperText={`${text.length}/${maxLength}`}
-        InputProps={{
-          style: {
-            height: "300px", // テキストエリアの高さを調整
-          },
-        }}
-        rows={10}
-      />
-    </Box>
+    <Container
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        height: "100vh",
+      }}
+    >
+      <Container sx={{ pt: 3 }}>
+        <TopSection />
+        <Stack sx={{ margin: "30px auto 0", width: "90%" }}>
+          <Typography variant="h4" sx={{ mb: 4, fontWeight: "bold", textAlign: "left" }}>
+            <EditNoteIcon sx={{ fontSize: 40, mr: 2, verticalAlign: "bottom" }} />
+            持ち込みメモ
+          </Typography>
+          <MemoInputField />
+        </Stack>
+      </Container>
+    </Container>
   );
 };
 

--- a/frontend/src/components/pages/Waiting.tsx
+++ b/frontend/src/components/pages/Waiting.tsx
@@ -1,8 +1,8 @@
 import { Box, Button, Container, Typography } from "@mui/material";
 import CircularProgress from "@mui/material/CircularProgress";
-import { Memo } from "./Memo";
 import TopSection from "../utils/TopSection";
 import { BottomNavigationTemplate } from "../templates/BottomNavigationTemplate";
+import { MemoInputField } from "../utils/MemoInputField";
 
 const WaitingCotainer = () => {
   return (
@@ -17,7 +17,7 @@ const WaitingCotainer = () => {
           <Typography variant="subtitle1" gutterBottom component="div">
             持ち込みメモ
           </Typography>
-          <Memo />
+          <MemoInputField />
         </Box>
 
         <Button variant="contained" sx={{ mt: 4, color: "#000", bgcolor: "secondary.main", "&:hover": { bgcolor: "secondary.dark" }, width: "80%", maxWidth: "300px" }}>

--- a/frontend/src/components/utils/MemoInputField.tsx
+++ b/frontend/src/components/utils/MemoInputField.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from "react";
+import { TextField } from "@mui/material";
+
+export const MemoInputField = () => {
+  const [text, setText] = useState("");
+  const maxLength = 500;
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setText(event.target.value.slice(0, maxLength));
+  };
+
+  return (
+    <TextField
+      label="持ち込みメモ"
+      multiline
+      fullWidth
+      variant="outlined"
+      value={text}
+      onChange={handleChange}
+      helperText={`${text.length}/${maxLength}`}
+      InputProps={{
+        style: {
+          height: "300px", // テキストエリアの高さを調整
+        },
+      }}
+      rows={10}
+      sx={{ bgcolor: "secondary.main", borderRadius: 2 }}
+    />
+  );
+};


### PR DESCRIPTION
## チケットへのリンク

- なし

## やったこと

- 持ち込みメモ画面の入力フィールドのスタイルの調整
- 保存ボタンの追加

## やらないこと

- 保存機能は別で実装する

## できるようになること（ユーザ目線）

- なし

## できなくなること（ユーザ目線）

- なし

## 動作確認

- npm run dev で動作確認済み

## その他

- 特になし
