### PR TITLE
feat: マイクチェック後の画面の作成

### DIFF
--- a/frontend/src/components/pages/MicCheck.tsx
+++ b/frontend/src/components/pages/MicCheck.tsx
@@ -1,10 +1,12 @@
-import { Box, Button, Container, Typography } from "@mui/material";
-import { Stack } from "@mui/system";
+import { Container } from "@mui/material";
 import TopSection from "../utils/TopSection";
-import { MicIcon } from "../utils/MicIcon";
-import AudioVisualizer from "../utils/AudioVisualizer";
+import { MicCheckScreen } from "../utils/MicCheckScreen";
+import { useState } from "react";
+import { MicCheckFinished } from "../utils/MicCheckFinished";
 
 export const MicCheck = () => {
+  const [isMicChecked, setIsMicChecked] = useState(false);
+  const handleMicCheck = () => setIsMicChecked(true);
   return (
     <Container
       sx={{
@@ -15,26 +17,7 @@ export const MicCheck = () => {
     >
       <Container sx={{ pt: 3, pb: 3 }}>
         <TopSection />
-        <Stack sx={{ margin: "30px auto 0", width: "90%" }}>
-          <Typography variant="h5" fontWeight="bolder" textAlign="left">
-            セッション前に
-            <br />
-            マイクチェックをするよ！
-          </Typography>
-          <Button variant="contained" sx={{ width: "50%", p: 2, display: "block", m: "10% auto", fontSize: "1.2rem", borderRadius: 3 }}>
-            準備OK!
-          </Button>
-          <Typography variant="h5" textAlign="left" fontWeight="bolder" color="primary.main" fontSize="1.7rem">
-            "I'll&ensp;enjoy&ensp;speaking&ensp;English!!"
-          </Typography>
-          <Typography variant="h5" textAlign="right" fontWeight="bolder" color="primary.main" fontSize="1.7rem">
-            と言おう！
-          </Typography>
-          <Box sx={{ width: "100%", display: "grid", placeContent: "center", mt: 4 }}>
-            <AudioVisualizer />
-            <MicIcon />
-          </Box>
-        </Stack>
+        {isMicChecked ? <MicCheckFinished /> : <MicCheckScreen isMicChecked={handleMicCheck} />}
       </Container>
     </Container>
   );

--- a/frontend/src/components/utils/MicCheckFinished.tsx
+++ b/frontend/src/components/utils/MicCheckFinished.tsx
@@ -1,0 +1,30 @@
+import { Box, Button, Stack, Typography } from "@mui/material";
+import { MicIcon } from "./MicIcon";
+import { useNavigate } from "react-router-dom";
+
+export const MicCheckFinished = () => {
+  const navigate = useNavigate();
+
+  return (
+    <Stack sx={{ margin: "30px auto 0", width: "90%" }}>
+      <Typography variant="h3" sx={{ mb: 1, textAlign: "left", color: "primary.main", fontFamily: "bangers" }}>
+        NICE!
+      </Typography>
+      <Typography variant="h5" fontWeight="bolder" textAlign="center" sx={{ mt: "10%", mb: "10%" }}>
+        マイクチェック完了！
+      </Typography>
+      <Typography variant="h6" fontWeight="bolder" sx={{ fontSize: "1.1rem" }}>
+        あと少しでセッションが始まるよ！
+      </Typography>
+      <Typography variant="h6" fontWeight="bolder" sx={{ fontSize: "1.1rem" }}>
+        準備はいいかな？
+      </Typography>
+      <Button variant="contained" sx={{ width: "50%", p: 2, display: "block", m: "10% auto", fontSize: "1.2rem", borderRadius: 3 }} onClick={() => navigate("/session")}>
+        準備OK!
+      </Button>
+      <Box sx={{ width: "100%", display: "grid", placeContent: "center", mt: 4 }}>
+        <MicIcon />
+      </Box>
+    </Stack>
+  );
+};

--- a/frontend/src/components/utils/MicCheckScreen.tsx
+++ b/frontend/src/components/utils/MicCheckScreen.tsx
@@ -1,0 +1,32 @@
+import { Box, Button, Stack, Typography } from "@mui/material";
+import AudioVisualizer from "./AudioVisualizer";
+import { MicIcon } from "./MicIcon";
+
+interface MicCheckScreenProps {
+  isMicChecked: () => void;
+}
+
+export const MicCheckScreen = ({ isMicChecked }: MicCheckScreenProps) => {
+  return (
+    <Stack sx={{ margin: "30px auto 0", width: "90%" }}>
+      <Typography variant="h5" fontWeight="bolder" textAlign="left">
+        セッション前に
+        <br />
+        マイクチェックをするよ！
+      </Typography>
+      <Button variant="contained" sx={{ width: "50%", p: 2, display: "block", m: "10% auto", fontSize: "1.2rem", borderRadius: 3 }} onClick={isMicChecked}>
+        準備OK!
+      </Button>
+      <Typography variant="h5" textAlign="left" fontWeight="bolder" color="primary.main" fontSize="1.7rem">
+        "I'll&ensp;enjoy&ensp;speaking&ensp;English!!"
+      </Typography>
+      <Typography variant="h5" textAlign="right" fontWeight="bolder" color="primary.main" fontSize="1.7rem">
+        と言おう！
+      </Typography>
+      <Box sx={{ width: "100%", display: "grid", placeContent: "center", mt: 4 }}>
+        <AudioVisualizer />
+        <MicIcon />
+      </Box>
+    </Stack>
+  );
+};


### PR DESCRIPTION
## チケットへのリンク

- なし

## やったこと

- マイクチェック後の画面を作成

## やらないこと

- なし

## できるようになること（ユーザ目線）

- マイクチェック後，セッション画面に遷移することができる

## できなくなること（ユーザ目線）

- なし

## 動作確認

- npm run dev で動作確認済み

## その他

- 特になし
