### PR TITLE
Feature/frontend/trophy notification

### DIFF
--- a/frontend/src/components/pages/Home.tsx
+++ b/frontend/src/components/pages/Home.tsx
@@ -11,6 +11,7 @@ import session from "../../mock/sessions.json";
 type SessionData = {
   dateTime: string;
   sessions: number[];
+  theme: string;
 };
 
 const HomeContainer = () => {
@@ -47,7 +48,7 @@ const HomeContainer = () => {
         >
           <h3>直近の参加予定</h3>
           <Typography sx={{ mt: 1, mb: 1, color: "primary.main", fontSize: "1.3rem", fontWeight: "bolder", textAlign: "center" }}>{sessionData[0]?.dateTime}</Typography>
-          {sessionData[0]?.sessions.map((session) => <Typography sx={{ color: "primary.main", textAlign: "center", fontSize: "0.9rem" }}>セッション{session}</Typography>)}
+          <Typography sx={{ color: "primary.main", fontSize: "1rem", fontWeight: "bolder", textAlign: "center" }}>テーマ: {sessionData[0]?.theme}</Typography>
         </Box>
 
         <Box

--- a/frontend/src/components/pages/Settings.tsx
+++ b/frontend/src/components/pages/Settings.tsx
@@ -159,16 +159,16 @@ const SettingsContainer = () => {
 
   const getRankColor = (rank: number) => {
     switch (rank) {
-      case 5:
-        return "#F3B500";
-      case 4:
-        return "#C0C0C0";
-      case 3:
-        return "#CD7F32";
-      case 2:
-        return "#00BFFF";
       case 1:
         return "#00FF00";
+      case 2:
+        return "#00BFFF";
+      case 3:
+        return "#CD7F32";
+      case 4:
+        return "#C0C0C0";
+      case 5:
+        return "#F3B500";
       default:
         return "#000000";
     }

--- a/frontend/src/components/pages/Settings.tsx
+++ b/frontend/src/components/pages/Settings.tsx
@@ -10,6 +10,7 @@ import { BottomNavigationTemplate } from "../templates/BottomNavigationTemplate"
 import api from "../../services/api";
 import { ArrowBack } from "@mui/icons-material";
 import { useNavigate } from "react-router-dom";
+import MilitaryTechIcon from "@mui/icons-material/MilitaryTech";
 interface UserData {
   id: number;
   username: string;
@@ -20,10 +21,12 @@ interface UserData {
   updated_at: string;
 }
 
+const rank = 5;
+
 // ユーザー名の最大文字数
 const MAX_USERNAME_LENGTH = 10;
 // メールアドレスの最大文字数
-const MAX_EMAIL_LENGTH = 15;
+const MAX_EMAIL_LENGTH = 20;
 
 const StyledPaper = styled(Paper)(({ theme }) => ({
   padding: theme.spacing(3),
@@ -154,6 +157,23 @@ const SettingsContainer = () => {
     navigate(-1);
   };
 
+  const getRankColor = (rank: number) => {
+    switch (rank) {
+      case 5:
+        return "#F3B500";
+      case 4:
+        return "#C0C0C0";
+      case 3:
+        return "#CD7F32";
+      case 2:
+        return "#00BFFF";
+      case 1:
+        return "#00FF00";
+      default:
+        return "#000000";
+    }
+  };
+
   //文字列を切り捨てる
   const truncateString = (str: string, num: number) => {
     if (!str) {
@@ -199,24 +219,27 @@ const SettingsContainer = () => {
                   </UploadButton>
                 </AvatarUpload>
                 <Box>
-                  {editName ? (
-                    <Box sx={{ display: "flex", alignItems: "center", mb: 1 }}>
-                      <StyledTextField value={newName} onChange={(e) => setNewName(e.target.value)} variant="outlined" size="small" />
-                      <IconButton onClick={handleSaveName} size="small" sx={{ ml: 1 }}>
-                        <CheckIcon />
-                      </IconButton>
-                      <IconButton onClick={() => setEditName(false)} size="small">
-                        <CloseIcon />
-                      </IconButton>
-                    </Box>
-                  ) : (
-                    <Box sx={{ display: "flex", alignItems: "center", mb: 1 }}>
-                      <Typography variant="h6">{truncateString(user.username, MAX_USERNAME_LENGTH)}</Typography>
-                      <IconButton onClick={() => setEditName(true)} size="small" sx={{ ml: 1 }}>
-                        <EditIcon fontSize="small" />
-                      </IconButton>
-                    </Box>
-                  )}
+                  <Box sx={{ display: "flex", alignItems: "center", mb: 1 }}>
+                    <MilitaryTechIcon sx={{ color: getRankColor(rank), marginRight: 1 }} />{" "}
+                    {editName ? (
+                      <Box sx={{ display: "flex", alignItems: "center" }}>
+                        <StyledTextField value={newName} onChange={(e) => setNewName(e.target.value)} variant="outlined" size="small" />
+                        <IconButton onClick={handleSaveName} size="small" sx={{ ml: 1 }}>
+                          <CheckIcon />
+                        </IconButton>
+                        <IconButton onClick={() => setEditName(false)} size="small">
+                          <CloseIcon />
+                        </IconButton>
+                      </Box>
+                    ) : (
+                      <Box sx={{ display: "flex", alignItems: "center" }}>
+                        <Typography variant="h6">{truncateString(user.username, MAX_USERNAME_LENGTH)}</Typography>
+                        <IconButton onClick={() => setEditName(true)} size="small" sx={{ ml: 1 }}>
+                          <EditIcon fontSize="small" />
+                        </IconButton>
+                      </Box>
+                    )}
+                  </Box>
                   {editEmail ? (
                     <Box sx={{ display: "flex", alignItems: "center" }}>
                       <StyledTextField value={newEmail} onChange={(e) => setNewEmail(e.target.value)} variant="outlined" size="small" />

--- a/frontend/src/components/pages/Settings.tsx
+++ b/frontend/src/components/pages/Settings.tsx
@@ -20,6 +20,11 @@ interface UserData {
   updated_at: string;
 }
 
+// ユーザー名の最大文字数
+const MAX_USERNAME_LENGTH = 10;
+// メールアドレスの最大文字数
+const MAX_EMAIL_LENGTH = 15;
+
 const StyledPaper = styled(Paper)(({ theme }) => ({
   padding: theme.spacing(3),
   borderRadius: theme.shape.borderRadius * 2,
@@ -149,6 +154,17 @@ const SettingsContainer = () => {
     navigate(-1);
   };
 
+  //文字列を切り捨てる
+  const truncateString = (str: string, num: number) => {
+    if (!str) {
+      return "";
+    }
+    if (str.length <= num) {
+      return str;
+    }
+    return str.slice(0, num) + "...";
+  };
+
   return (
     <Container sx={{ display: "flex", flexDirection: "column", justifyContent: "space-between", height: "100vh" }}>
       <Container sx={{ pt: 3 }}>
@@ -195,7 +211,7 @@ const SettingsContainer = () => {
                     </Box>
                   ) : (
                     <Box sx={{ display: "flex", alignItems: "center", mb: 1 }}>
-                      <Typography variant="h6">{user.username}</Typography>
+                      <Typography variant="h6">{truncateString(user.username, MAX_USERNAME_LENGTH)}</Typography>
                       <IconButton onClick={() => setEditName(true)} size="small" sx={{ ml: 1 }}>
                         <EditIcon fontSize="small" />
                       </IconButton>
@@ -214,7 +230,7 @@ const SettingsContainer = () => {
                   ) : (
                     <Box sx={{ display: "flex", alignItems: "center" }}>
                       <Typography variant="body1" color="text.secondary">
-                        {user.email}
+                        {truncateString(user.email, MAX_EMAIL_LENGTH)}
                       </Typography>
                       <IconButton onClick={() => setEditEmail(true)} size="small" sx={{ ml: 1 }}>
                         <EditIcon fontSize="small" />

--- a/frontend/src/components/pages/Settings.tsx
+++ b/frontend/src/components/pages/Settings.tsx
@@ -1,18 +1,5 @@
 import { useState, useEffect } from "react";
-import {
-  Box,
-  Typography,
-  IconButton,
-  Avatar,
-  TextField,
-  Button,
-  Paper,
-  Grid,
-  Divider,
-  useTheme,
-  styled,
-  Container,
-} from "@mui/material";
+import { Box, Typography, IconButton, Avatar, TextField, Button, Paper, Grid, Divider, useTheme, styled, Container } from "@mui/material";
 import EditIcon from "@mui/icons-material/Edit";
 import SettingsIcon from "@mui/icons-material/Settings";
 import LogoutIcon from "@mui/icons-material/Logout";
@@ -21,6 +8,8 @@ import CheckIcon from "@mui/icons-material/Check";
 import CloseIcon from "@mui/icons-material/Close";
 import { BottomNavigationTemplate } from "../templates/BottomNavigationTemplate";
 import api from "../../services/api";
+import { ArrowBack } from "@mui/icons-material";
+import { useNavigate } from "react-router-dom";
 interface UserData {
   id: number;
   username: string;
@@ -68,6 +57,7 @@ const SettingsContainer = () => {
   const [editEmail, setEditEmail] = useState(false);
   const [newName, setNewName] = useState("");
   const [newEmail, setNewEmail] = useState("");
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchUserData = async () => {
@@ -81,13 +71,13 @@ const SettingsContainer = () => {
         console.error("Failed to fetch user data:", error);
       }
     };
-  
+
     fetchUserData();
   }, []);
 
   const getFullAvatarUrl = (avatarUrl: string) => {
-    if (!avatarUrl) return ''; // デフォルトのアバター画像のURLを設定することもできます
-    if (avatarUrl.startsWith('http')) return avatarUrl; // すでに完全なURLの場合
+    if (!avatarUrl) return ""; // デフォルトのアバター画像のURLを設定することもできます
+    if (avatarUrl.startsWith("http")) return avatarUrl; // すでに完全なURLの場合
     return `http://localhost:8081${avatarUrl}`; // ローカル開発環境の場合
   };
 
@@ -95,14 +85,14 @@ const SettingsContainer = () => {
     if (event.target.files && event.target.files[0]) {
       const formData = new FormData();
       formData.append("avatar", event.target.files[0]);
-  
+
       try {
         const response = await api.put("/user/avatar", formData, {
           headers: {
             "Content-Type": "multipart/form-data",
           },
         });
-        setUser((prevUser) => prevUser ? { ...prevUser, avatar_url: response.data.avatar_url } : null);
+        setUser((prevUser) => (prevUser ? { ...prevUser, avatar_url: response.data.avatar_url } : null));
       } catch (error) {
         console.error("Failed to upload avatar:", error);
         // Handle error (e.g., show notification)
@@ -143,7 +133,6 @@ const SettingsContainer = () => {
       updateUser();
     }
   };
-  
 
   const handleLogout = () => {
     // Implement logout logic
@@ -156,18 +145,31 @@ const SettingsContainer = () => {
     return <Typography>Loading...</Typography>;
   }
 
+  const handleGoBack = () => {
+    navigate(-1);
+  };
+
   return (
-    <Container
-      sx={{ display: "flex", flexDirection: "column", justifyContent: "space-between", height: "100vh" }}
-    >
+    <Container sx={{ display: "flex", flexDirection: "column", justifyContent: "space-between", height: "100vh" }}>
       <Container sx={{ pt: 3 }}>
-        <Typography
-          variant="h4"
-          sx={{ mb: 4, fontWeight: "bold", textAlign: "left" }}
+        <Box
+          sx={{
+            position: "relative",
+            display: "flex",
+            justifyContent: "flex-start",
+            alignItems: "center",
+            pt: 2,
+            pb: 2,
+          }}
         >
-          <SettingsIcon sx={{ fontSize: 40, mr: 2, verticalAlign: "bottom" }} />
-          設定
-        </Typography>
+          <IconButton onClick={handleGoBack}>
+            <ArrowBack sx={{ fontSize: 40 }} />
+          </IconButton>
+          <Typography variant="h4" sx={{ fontWeight: "bold", textAlign: "left" }}>
+            <SettingsIcon sx={{ fontSize: 40, mr: 2, verticalAlign: "bottom" }} />
+            設定
+          </Typography>
+        </Box>
 
         <Grid container spacing={4}>
           <Grid item xs={12} md={6}>
@@ -183,12 +185,7 @@ const SettingsContainer = () => {
                 <Box>
                   {editName ? (
                     <Box sx={{ display: "flex", alignItems: "center", mb: 1 }}>
-                      <StyledTextField
-                        value={newName}
-                        onChange={(e) => setNewName(e.target.value)}
-                        variant="outlined"
-                        size="small"
-                      />
+                      <StyledTextField value={newName} onChange={(e) => setNewName(e.target.value)} variant="outlined" size="small" />
                       <IconButton onClick={handleSaveName} size="small" sx={{ ml: 1 }}>
                         <CheckIcon />
                       </IconButton>
@@ -206,12 +203,7 @@ const SettingsContainer = () => {
                   )}
                   {editEmail ? (
                     <Box sx={{ display: "flex", alignItems: "center" }}>
-                      <StyledTextField
-                        value={newEmail}
-                        onChange={(e) => setNewEmail(e.target.value)}
-                        variant="outlined"
-                        size="small"
-                      />
+                      <StyledTextField value={newEmail} onChange={(e) => setNewEmail(e.target.value)} variant="outlined" size="small" />
                       <IconButton onClick={handleSaveEmail} size="small" sx={{ ml: 1 }}>
                         <CheckIcon />
                       </IconButton>

--- a/frontend/src/components/pages/TrophyNotification.tsx
+++ b/frontend/src/components/pages/TrophyNotification.tsx
@@ -1,0 +1,42 @@
+import { Box, Typography, Container } from "@mui/material";
+import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
+
+const TrophyNotification = () => {
+  return (
+    <Container sx={{ p: 0, width: "100%", height: "100vh", display: "grid", placeItems: "center" }}>
+      <Container
+        sx={{
+          p: 0,
+          width: "100%",
+          height: "60vh",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <Box
+          sx={{
+            width: "100%",
+            bgcolor: "white",
+            textAlign: "center",
+            py: 3,
+            mt: 4,
+          }}
+        >
+          <Typography variant="h4" component="h1" sx={{ color: "primary.main", fontWeight: "bold" }}>
+            トロフィー獲得！
+          </Typography>
+        </Box>
+
+        <EmojiEventsIcon sx={{ fontSize: 200, color: "black" }} />
+
+        <Typography variant="body1" sx={{ mb: 4, fontWeight: "bold" }}>
+          初めてのセッションに参加
+        </Typography>
+      </Container>
+    </Container>
+  );
+};
+
+export default TrophyNotification;

--- a/frontend/src/components/pages/Waiting.tsx
+++ b/frontend/src/components/pages/Waiting.tsx
@@ -1,12 +1,19 @@
-import { Box, Button, Container, Typography } from "@mui/material";
+import { Box, Button, Container, IconButton, Typography } from "@mui/material";
 import CircularProgress from "@mui/material/CircularProgress";
 import TopSection from "../utils/TopSection";
 import { BottomNavigationTemplate } from "../templates/BottomNavigationTemplate";
 import { MemoInputField } from "../utils/MemoInputField";
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ArrowBack } from "@mui/icons-material";
 
 const WaitingContainer = () => {
   const [memo, setMemo] = useState("");
+  const navigate = useNavigate();
+
+  const handleGoBack = () => {
+    navigate(-1);
+  };
 
   return (
     <Container sx={{ height: "100vh", padding: 3 }}>
@@ -18,8 +25,12 @@ const WaitingContainer = () => {
           flexDirection: "column",
           alignItems: "center",
           justifyContent: "center",
+          position: "relative",
         }}
       >
+        <IconButton onClick={handleGoBack} sx={{ position: "absolute", top: 0, left: 3 }}>
+          <ArrowBack sx={{ fontSize: 40 }} />
+        </IconButton>
         <Typography
           variant="h6"
           sx={{
@@ -49,11 +60,7 @@ const WaitingContainer = () => {
           <Typography variant="subtitle1" gutterBottom component="div">
             持ち込みメモ
           </Typography>
-          <MemoInputField
-            value={memo}
-            onChange={setMemo}
-            label="メモ入力"
-          />
+          <MemoInputField value={memo} onChange={setMemo} label="メモ入力" />
         </Box>
 
         <Button

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -24,6 +24,7 @@ import AdminPage from "./components/pages/AdminPage.tsx";
 import FriendList from "./components/utils/FriendList.tsx";
 import Theme from "./styles/Theme.tsx";
 import { SessionHistoryFriendlist } from "./components/pages/SessionHistoryFriendlist.tsx";
+import TrophyNotification from "./components/pages/TrophyNotification.tsx";
 
 const router = createBrowserRouter([
   {
@@ -109,7 +110,11 @@ const router = createBrowserRouter([
   {
     path: "sessionfeedback",
     element: <SessionFeedback />,
-  }
+  },
+  {
+    path: "trophynotification",
+    element: <TrophyNotification />,
+  },
 ]);
 
 const rootElement = document.getElementById("root");

--- a/frontend/src/mock/sessions.json
+++ b/frontend/src/mock/sessions.json
@@ -1,17 +1,21 @@
 [
   {
+  "theme": "好きな言葉",
   "dateTime": "5月15日10:00",
   "sessions": [1, 2, 3]
   },
   {
+  "theme": "好きな食べ物",
   "dateTime": "5月15日20:00",
   "sessions": [1, 2]
   },
   {
+  "theme": "好きな映画",
   "dateTime": "5月16日10:00",
   "sessions": [1, 3]
   },
   {
+  "theme": "好きな本",
   "dateTime": "5月20日17:00",
   "sessions": [1, 2, 3]
   }


### PR DESCRIPTION
## チケットへのリンク

- #75 #73 #70 

## やったこと

- 設定画面に戻るボタンを追加
- 待機画面に戻るボタンを追加
- ユーザのランクをアイコンで表示
- トロフィー獲得画面を作成

## やらないこと

- なし

## できるようになること（ユーザ目線）

- 設定画面から一つ前の画面に戻ることができる
- 待機画面から一つ前の画面に戻ることができる
- ランクの確認ができる

## できなくなること（ユーザ目線）

- なし

## 動作確認

- npm run dev で動作確認済み

## その他

- 特になし
