### PR TITLE
fix: sessionCountDownModalの縦幅が足りていない点を修正

### DIFF
--- a/frontend/src/components/utils/SessionCountDownModal.tsx
+++ b/frontend/src/components/utils/SessionCountDownModal.tsx
@@ -23,20 +23,21 @@ const SessionCountDownModal = () => {
   return (
     <Box
       sx={{
-        height: "80vh",
-        width: "90vw",
+        height: "calc(100vh - 70px)",
+        width: "100vw",
         bgcolor: "background.default",
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
-        justifyContent: "space-between",
+        justifyContent: "center",
+        p: 5,
       }}
     >
       <Box sx={{ textAlign: "center", mt: 4, width: "90%" }}>
         <Typography variant="h5" component="p" fontWeight="bold" textAlign="left">
           会話まで...
         </Typography>
-        <Typography variant="h1" component="p" color="primary" fontWeight="bold" sx={{ mt: 2, fontSize: "6rem" }}>
+        <Typography variant="h1" component="p" color="primary" fontWeight="bold" sx={{ mt: 2, mb: 4, fontSize: "6rem", fontFamily: "bangers" }}>
           {countdown}
         </Typography>
       </Box>


### PR DESCRIPTION
## チケットへのリンク

- なす

## やったこと

- sessionCoundDownModalの縦幅の調整

## やらないこと

- なし

## できるようになること（ユーザ目線）

- なし

## できなくなること（ユーザ目線）

- なし

## 動作確認

- npm run dev で動作確認済み

## その他

- 特になし
