### PR TITLE
Feature/frontend/session roop

### DIFF
--- a/frontend/src/components/pages/Session.tsx
+++ b/frontend/src/components/pages/Session.tsx
@@ -37,10 +37,10 @@ const STUN_SERVERS = {
 type UserCardData = {
   name: string;
   icon: JSX.Element;
-}
-
+};
 
 export const Session = () => {
+  const sessionTime = 300; // [s]
   const [memoOpen, setMemoOpen] = useState(false);
   const [assistantOpen, setAssistantOpen] = useState(false);
   const [messages, setMessages] = useState<string[]>([]);
@@ -50,7 +50,7 @@ export const Session = () => {
   const [memo2, setMemo2] = useState(""); // メモ2を管理
   const [value, setValue] = useState("1");
   const [isMuted, setIsMuted] = useState(false);
-  const [countdown, setCountdown] = useState(303);
+  const [countdown, setCountdown] = useState(sessionTime + 3);
   const navigate = useNavigate();
   const { sessionStep, setSessionStep } = useContext(SessionStepContext);
 
@@ -265,7 +265,9 @@ export const Session = () => {
     pc.ontrack = (event: RTCTrackEvent) => {
       if (remoteAudioRef.current && event.streams[0]) {
         remoteAudioRef.current.srcObject = event.streams[0];
-        opponentVolumeAnalyzerRef.current = new AudioVolumeAnalyzer(setIsOpponentSpeak);
+        opponentVolumeAnalyzerRef.current = new AudioVolumeAnalyzer(
+          setIsOpponentSpeak
+        );
         opponentVolumeAnalyzerRef.current.start(event.streams[0]);
       }
     };
@@ -326,7 +328,6 @@ export const Session = () => {
 
       volumeAnalyzerRef.current = new AudioVolumeAnalyzer(setisSpeak);
       volumeAnalyzerRef.current.start(stream);
-
     } catch (error) {
       console.error("Error starting call:", error);
       cleanupResources();
@@ -387,12 +388,14 @@ export const Session = () => {
 
   // userInfo
   const initialUserCardInfo = { name: "", icon: <Person /> };
-  const [userCardInfo, setUserCardInfo] = useState<UserCardData>(initialUserCardInfo);
-  const [opponentUserCardInfo, setOpponentUserCardInfo] = useState<UserCardData>(initialUserCardInfo);
+  const [userCardInfo, setUserCardInfo] =
+    useState<UserCardData>(initialUserCardInfo);
+  const [opponentUserCardInfo, setOpponentUserCardInfo] =
+    useState<UserCardData>(initialUserCardInfo);
 
   const getFullAvatarUrl = (avatarUrl: string) => {
-    if (!avatarUrl) return ''; // デフォルトのアバター画像のURLを設定することもできます
-    if (avatarUrl.startsWith('http')) return avatarUrl; // すでに完全なURLの場合
+    if (!avatarUrl) return ""; // デフォルトのアバター画像のURLを設定することもできます
+    if (avatarUrl.startsWith("http")) return avatarUrl; // すでに完全なURLの場合
     return `http://localhost:8081${avatarUrl}`; // ローカル開発環境の場合
   };
 
@@ -400,12 +403,21 @@ export const Session = () => {
     const fetchUserData = async () => {
       try {
         const userInfoResponse = await api.get<UserData>("/user/info");
-        const opponentUserCardDataResponse = await api.get<UserData>("/user/info");
+        const opponentUserCardDataResponse =
+          await api.get<UserData>("/user/info");
         const userInfo: UserCardData = {
           name: userInfoResponse.data.username,
-          icon: <Avatar src={getFullAvatarUrl(userInfoResponse.data.avatar_url)} sx={{ width: 80, height: 80 }} />
+          icon: (
+            <Avatar
+              src={getFullAvatarUrl(userInfoResponse.data.avatar_url)}
+              sx={{ width: 80, height: 80 }}
+            />
+          ),
         };
-        const opponentUserInfo: UserCardData = { name: opponentUserCardDataResponse.data.username, icon: <Person /> };
+        const opponentUserInfo: UserCardData = {
+          name: opponentUserCardDataResponse.data.username,
+          icon: <Person />,
+        };
         setUserCardInfo(userInfo);
         setOpponentUserCardInfo(opponentUserInfo);
       } catch (error) {
@@ -553,4 +565,3 @@ export const Session = () => {
 };
 
 export default Session;
-

--- a/frontend/src/components/pages/Session.tsx
+++ b/frontend/src/components/pages/Session.tsx
@@ -1,5 +1,5 @@
 import { HalfModal } from "../utils/HalfModal";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import {
   Typography,
   Box,
@@ -23,6 +23,7 @@ import { useNavigate } from "react-router-dom";
 import { TopicPopup } from "../utils/TopicPopup";
 import { AudioVolumeAnalyzer } from "../utils/AudioVolumeAnalyzer";
 import { UserData } from "./Settings";
+import { SessionStepContext } from "../utils/SessionStepContextProvider";
 
 const theme = "好きな言葉";
 
@@ -51,6 +52,7 @@ export const Session = () => {
   const [isMuted, setIsMuted] = useState(false);
   const [countdown, setCountdown] = useState(303);
   const navigate = useNavigate();
+  const { sessionStep, setSessionStep } = useContext(SessionStepContext);
 
   const [showTopicPopup, setShowTopicPopup] = useState(false);
   const [isPriorityHighClicked, setIsPriorityHighClicked] = useState(false);
@@ -70,6 +72,11 @@ export const Session = () => {
       return () => clearTimeout(timer);
     } else {
       navigate("/sessioninterval");
+      const nextStep = sessionStep + 1;
+      setSessionStep(nextStep);
+      if (nextStep >= 3) {
+        navigate("/sessionrecord");
+      }
     }
   }, [countdown, navigate]);
   useEffect(() => {

--- a/frontend/src/components/pages/SessionInterval.tsx
+++ b/frontend/src/components/pages/SessionInterval.tsx
@@ -2,13 +2,17 @@ import { Box, Container, Typography } from "@mui/material";
 import { Stack } from "@mui/system";
 import TopSection from "../utils/TopSection";
 import { MemoInputField } from "../utils/MemoInputField";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { SessionStepContext } from "../utils/SessionStepContextProvider";
 
 export const SessionInterval = () => {
   const intervalTime = 60; // [s]
   const [countdown, setCountdown] = useState(intervalTime);
   const navigate = useNavigate();
+  const [memoValue, setMemoValue] = useState("");
+  const { learnedExpressions, setLearnedExpressions } =
+    useContext(SessionStepContext);
 
   useEffect(() => {
     if (countdown > 0) {
@@ -16,6 +20,8 @@ export const SessionInterval = () => {
       return () => clearTimeout(timer);
     } else {
       navigate("/session");
+      const newLearnedExpression = learnedExpressions + "\n" + memoValue;
+      setLearnedExpressions(newLearnedExpression);
     }
   }, [countdown, navigate]);
   return (
@@ -28,6 +34,7 @@ export const SessionInterval = () => {
       }}
     >
       <Container sx={{ pt: 3 }}>
+        {learnedExpressions}
         <TopSection />
         <Stack sx={{ margin: "30px auto 0", width: "90%" }}>
           <Typography
@@ -45,8 +52,8 @@ export const SessionInterval = () => {
             今のセッションで学んだことをメモしておこう！
           </Typography>
           <MemoInputField
-            value={""}
-            onChange={() => {}}
+            value={memoValue}
+            setValue={setMemoValue}
             label="学んだ表現"
             height="30vh"
           />

--- a/frontend/src/components/pages/SessionInterval.tsx
+++ b/frontend/src/components/pages/SessionInterval.tsx
@@ -20,6 +20,10 @@ export const SessionInterval = () => {
       return () => clearTimeout(timer);
     } else {
       navigate("/session");
+      if (learnedExpressions === "") {
+        setLearnedExpressions(memoValue);
+        return;
+      }
       const newLearnedExpression = learnedExpressions + "\n" + memoValue;
       setLearnedExpressions(newLearnedExpression);
     }
@@ -34,7 +38,6 @@ export const SessionInterval = () => {
       }}
     >
       <Container sx={{ pt: 3 }}>
-        {learnedExpressions}
         <TopSection />
         <Stack sx={{ margin: "30px auto 0", width: "90%" }}>
           <Typography

--- a/frontend/src/components/pages/SessionInterval.tsx
+++ b/frontend/src/components/pages/SessionInterval.tsx
@@ -6,7 +6,8 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 export const SessionInterval = () => {
-  const [countdown, setCountdown] = useState(60);
+  const intervalTime = 60; // [s]
+  const [countdown, setCountdown] = useState(intervalTime);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -29,18 +30,42 @@ export const SessionInterval = () => {
       <Container sx={{ pt: 3 }}>
         <TopSection />
         <Stack sx={{ margin: "30px auto 0", width: "90%" }}>
-          <Typography variant="h3" sx={{ mb: 1, textAlign: "left", color: "primary.main", fontFamily: "bangers" }}>
+          <Typography
+            variant="h3"
+            sx={{
+              mb: 1,
+              textAlign: "left",
+              color: "primary.main",
+              fontFamily: "bangers",
+            }}
+          >
             GREAT!
           </Typography>
           <Typography textAlign="left" sx={{ mb: 2 }}>
             今のセッションで学んだことをメモしておこう！
           </Typography>
-          <MemoInputField value={""} onChange={() => { }} label="学んだ表現" height="30vh" />
+          <MemoInputField
+            value={""}
+            onChange={() => {}}
+            label="学んだ表現"
+            height="30vh"
+          />
           <Box sx={{ textAlign: "center", mt: 2 }}>
-            <Typography variant="h6" component="p" fontWeight="bold" textAlign="left">
+            <Typography
+              variant="h6"
+              component="p"
+              fontWeight="bold"
+              textAlign="left"
+            >
               次のセッションまで...
             </Typography>
-            <Typography variant="h1" component="p" color="primary" fontWeight="bold" sx={{ mt: 2, fontSize: "5rem", fontFamily: "bangers" }}>
+            <Typography
+              variant="h1"
+              component="p"
+              color="primary"
+              fontWeight="bold"
+              sx={{ mt: 2, fontSize: "5rem", fontFamily: "bangers" }}
+            >
               {countdown}
             </Typography>
           </Box>

--- a/frontend/src/components/pages/SessionInterval.tsx
+++ b/frontend/src/components/pages/SessionInterval.tsx
@@ -35,7 +35,7 @@ export const SessionInterval = () => {
           <Typography textAlign="left" sx={{ mb: 2 }}>
             今のセッションで学んだことをメモしておこう！
           </Typography>
-          <MemoInputField value={""} onChange={() => {}} label="学んだ表現" height="30vh" />
+          <MemoInputField value={""} onChange={() => { }} label="学んだ表現" height="30vh" />
           <Box sx={{ textAlign: "center", mt: 2 }}>
             <Typography variant="h6" component="p" fontWeight="bold" textAlign="left">
               次のセッションまで...

--- a/frontend/src/components/pages/SessionRecordForm.tsx
+++ b/frontend/src/components/pages/SessionRecordForm.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 import { Box, Typography, TextField, Button, Paper, Container, Stack } from "@mui/material";
 import { styled } from "@mui/system";
 import { useNavigate } from "react-router-dom";
 import TopSection from "../utils/TopSection";
+import { SessionStepContext } from "../utils/SessionStepContextProvider";
 
 const DashedBox = styled(Paper)({
   border: "2px dashed #FFD700",
@@ -12,7 +13,7 @@ const DashedBox = styled(Paper)({
 const SessionRecordForm: React.FC = () => {
   const [satisfaction, setSatisfaction] = useState<string>("");
   const [thoughts, setThoughts] = useState<string>("");
-  const [learnedExpressions, setLearnedExpressions] = useState<string>("");
+  const { learnedExpressions, setLearnedExpressions } = useContext(SessionStepContext);
   const navigate = useNavigate();
 
   const handleNext = () => {

--- a/frontend/src/components/utils/MemoInputField.tsx
+++ b/frontend/src/components/utils/MemoInputField.tsx
@@ -1,17 +1,24 @@
 import { TextField } from "@mui/material";
+import { Dispatch, SetStateAction } from "react";
 
 interface MemoInputFieldProps {
   value: string;
-  onChange: (value: string) => void;
+  setValue: Dispatch<SetStateAction<string>>;
   label: string;
   maxLength?: number;
   height?: string;
 }
 
-export const MemoInputField: React.FC<MemoInputFieldProps> = ({ value, onChange, label, maxLength = 500, height = "300px" }) => {
+export const MemoInputField: React.FC<MemoInputFieldProps> = ({
+  value,
+  setValue,
+  label,
+  maxLength = 500,
+  height = "300px",
+}) => {
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const text = event.target.value.slice(0, maxLength);
-    onChange(text);
+    setValue(text);
   };
 
   return (

--- a/frontend/src/components/utils/SessionStepContextProvider.tsx
+++ b/frontend/src/components/utils/SessionStepContextProvider.tsx
@@ -1,0 +1,18 @@
+import { createContext, Dispatch, ReactNode, SetStateAction, useState } from 'react';
+
+type SessionStepContextType = {
+    sessionStep: number;
+    setSessionStep: Dispatch<SetStateAction<number>>;
+}
+
+export const SessionStepContext = createContext<SessionStepContextType>({} as SessionStepContextType);
+
+export const SessionStepContextProvider = (props: { children: ReactNode }) => {
+    const [sessionStep, setSessionStep] = useState(0);
+    return (
+        <SessionStepContext.Provider value={{ sessionStep, setSessionStep }}>
+            {props.children}
+        </SessionStepContext.Provider >
+    )
+}
+

--- a/frontend/src/components/utils/SessionStepContextProvider.tsx
+++ b/frontend/src/components/utils/SessionStepContextProvider.tsx
@@ -3,14 +3,17 @@ import { createContext, Dispatch, ReactNode, SetStateAction, useState } from 're
 type SessionStepContextType = {
     sessionStep: number;
     setSessionStep: Dispatch<SetStateAction<number>>;
+    learnedExpressions: string;
+    setLearnedExpressions: Dispatch<SetStateAction<string>>;
 }
 
 export const SessionStepContext = createContext<SessionStepContextType>({} as SessionStepContextType);
 
 export const SessionStepContextProvider = (props: { children: ReactNode }) => {
     const [sessionStep, setSessionStep] = useState(0);
+    const [learnedExpressions, setLearnedExpressions] = useState("");
     return (
-        <SessionStepContext.Provider value={{ sessionStep, setSessionStep }}>
+        <SessionStepContext.Provider value={{ sessionStep, setSessionStep, learnedExpressions, setLearnedExpressions }}>
             {props.children}
         </SessionStepContext.Provider >
     )

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -25,6 +25,7 @@ import FriendList from "./components/utils/FriendList.tsx";
 import Theme from "./styles/Theme.tsx";
 import { SessionHistoryFriendlist } from "./components/pages/SessionHistoryFriendlist.tsx";
 import TrophyNotification from "./components/pages/TrophyNotification.tsx";
+import { SessionStepContext, SessionStepContextProvider } from "./components/utils/SessionStepContextProvider.tsx";
 
 const router = createBrowserRouter([
   {
@@ -122,8 +123,11 @@ if (rootElement) {
   createRoot(rootElement).render(
     <StrictMode>
       <ThemeProvider theme={Theme}>
-        <CssBaseline />
-        <RouterProvider router={router} />
+        <SessionStepContextProvider>
+          <RouterProvider router={router} />
+          <CssBaseline />
+          <RouterProvider router={router} />
+        </SessionStepContextProvider>
       </ThemeProvider>
     </StrictMode>
   );

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -126,7 +126,6 @@ if (rootElement) {
         <SessionStepContextProvider>
           <RouterProvider router={router} />
           <CssBaseline />
-          <RouterProvider router={router} />
         </SessionStepContextProvider>
       </ThemeProvider>
     </StrictMode>


### PR DESCRIPTION
## チケットへのリンク

- #66 

## やったこと

- sessionのループ語にsession recordに画面遷移
- session中で学んだ表現を記録して終了後session recordでまとめて表示

## やらないこと

-  User情報のfetch 
- テーマ
- 学んだ表現をDBに送信

## できるようになること（ユーザ目線）

- session終了後自動でsession recordに遷移できる
- 学んだ表現を記録しsession recordで確認できる

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- ブラウザで目視確認

## その他

- DB送信等はお任せします
